### PR TITLE
[FIX] Tune idle connection check frequency

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -98,7 +98,7 @@ func dialFuncWrapper(host string, authPass *string) func() (redis.Conn, error) {
 }
 
 func testOnBorrow(c redis.Conn, t time.Time) (err error) {
-	if time.Since(t) > time.Millisecond {
+	if time.Since(t) > time.Minute {
 		_, err = c.Do("PING")
 	}
 	return err


### PR DESCRIPTION
Reduce the client overhead for connection liveliness checks.

Tuned idle connection ping check threshold from 1 millisecond idle time to 1 minute idle time.
Based on the Redis client code example https://github.com/gomodule/redigo/blob/90a3d85/redis/pool.go#L107
