### PR TITLE
[TEST] fix after PR#354

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -227,7 +227,7 @@ func TestClient_TopkQuery(t *testing.T) {
 	keys, err := client.TopkList(key1)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(keys))
-	assert.Equal(t, []string{"A", "D", "B"}, keys)
+	assert.Equal(t, []string{"A", "B", "E"}, keys)
 }
 
 func TestClient_TopkInfo(t *testing.T) {


### PR DESCRIPTION
RedisBloom/RedisBloom#354 changed the flow and due to the probabilistic nature of TopK, have altered the results.
